### PR TITLE
Add option to limit outbound CIDRs

### DIFF
--- a/modules/vault-cluster/main.tf
+++ b/modules/vault-cluster/main.tf
@@ -186,12 +186,12 @@ resource "aws_security_group_rule" "allow_ssh_inbound_from_security_group_ids" {
   security_group_id = aws_security_group.lc_security_group.id
 }
 
-resource "aws_security_group_rule" "allow_all_outbound" {
+resource "aws_security_group_rule" "allow_outbound" {
   type        = "egress"
   from_port   = 0
   to_port     = 0
   protocol    = "-1"
-  cidr_blocks = ["0.0.0.0/0"]
+  cidr_blocks = var.allowed_outbound_cidr_blocks
 
   security_group_id = aws_security_group.lc_security_group.id
 }

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -24,6 +24,11 @@ variable "allowed_inbound_cidr_blocks" {
   type        = list(string)
 }
 
+variable "allowed_outbound_cidr_blocks" {
+  description = "A list of CIDR-formatted IP address ranges from which the EC2 Instances will allow connections from Vault"
+  type        = list(string)
+}
+
 variable "allowed_inbound_security_group_ids" {
   description = "A list of security group IDs that will be allowed to connect to Vault"
   type        = list(string)


### PR DESCRIPTION
This adds the option to limit where outbound requests from Vault can go.